### PR TITLE
Create whack-a-mole mini game experience

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,239 @@
 #root {
-  max-width: 1280px;
+  width: 100%;
+}
+
+.app {
+  width: min(720px, 100%);
   margin: 0 auto;
-  padding: 2rem;
+  padding: 2.5rem clamp(1.25rem, 4vw, 3rem) 3rem;
+  border-radius: 24px;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.92), rgba(226, 232, 240, 0.92));
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.25);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2rem;
+  backdrop-filter: blur(6px);
+}
+
+.header {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.header h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  color: #1d4ed8;
+}
+
+.header .lead {
+  margin: 0;
+  font-size: clamp(1rem, 2.6vw, 1.15rem);
+  color: #334155;
+}
+
+.status-panel {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1.25rem;
+}
+
+.status-block {
+  background: linear-gradient(160deg, rgba(59, 130, 246, 0.15), rgba(14, 165, 233, 0.1));
+  border-radius: 18px;
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  align-items: center;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6), 0 12px 24px rgba(15, 23, 42, 0.15);
+}
+
+.status-label {
+  font-size: 0.85rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #0f172a;
+  opacity: 0.7;
+}
+
+.status-value {
+  font-size: clamp(2rem, 4vw, 2.5rem);
+  font-weight: 700;
+  color: #0f172a;
+  text-shadow: 0 2px 4px rgba(255, 255, 255, 0.65);
+}
+
+.status-block.time {
+  align-items: stretch;
+}
+
+.status-block.time .status-value {
   text-align: center;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.time-track {
+  margin-top: 0.75rem;
+  width: 100%;
+  height: 0.55rem;
+  border-radius: 9999px;
+  background: rgba(15, 23, 42, 0.08);
+  overflow: hidden;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
+.time-progress {
+  height: 100%;
+  background: linear-gradient(90deg, #22d3ee 0%, #2563eb 100%);
+  transition: width 0.25s ease;
+}
+
+.board {
+  width: min(420px, 100%);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: clamp(0.75rem, 3vw, 1.1rem);
+}
+
+.hole {
+  position: relative;
+  padding-top: 100%;
+  border: none;
+  border-radius: 24px;
+  background: radial-gradient(circle at 50% 45%, #172554 0%, #0f172a 70%, #020617 100%);
+  box-shadow: inset 0 10px 25px rgba(15, 23, 42, 0.65), 0 20px 25px rgba(15, 23, 42, 0.25);
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.hole:disabled {
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: inset 0 10px 25px rgba(15, 23, 42, 0.5), 0 12px 18px rgba(15, 23, 42, 0.18);
+}
+
+.hole:not(:disabled):active {
+  transform: translateY(4px);
+}
+
+.hole-inner {
+  position: absolute;
+  inset: 12%;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
+
+.hole-shadow {
+  position: absolute;
+  bottom: 10%;
+  width: 60%;
+  height: 16%;
+  background: rgba(15, 23, 42, 0.6);
+  filter: blur(4px);
+  border-radius: 9999px;
+  opacity: 0;
+  transition: opacity 0.18s ease;
+}
+
+.mole {
+  position: relative;
+  width: 60%;
+  aspect-ratio: 1 / 1;
+  border-radius: 9999px;
+  background: radial-gradient(circle at 30% 30%, #facc15 0%, #f97316 60%, #c2410c 100%);
+  box-shadow: inset 0 6px 10px rgba(255, 255, 255, 0.55), 0 14px 20px rgba(15, 23, 42, 0.35);
+  transform: translateY(45%) scale(0.3);
+  opacity: 0;
+  transition: transform 0.18s ease, opacity 0.18s ease;
+  pointer-events: none;
+}
+
+.hole.has-mole .mole {
+  transform: translateY(0) scale(1);
+  opacity: 1;
+}
+
+.hole.has-mole .hole-shadow {
+  opacity: 1;
+}
+
+.controls {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.primary-button,
+.secondary-button {
+  border: none;
+  border-radius: 9999px;
+  font-size: 1.05rem;
+  font-weight: 700;
+  padding: 0.85rem 2.4rem;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+}
+
+.primary-button {
+  color: #f8fafc;
+  background: linear-gradient(135deg, #22d3ee 0%, #2563eb 100%);
+  box-shadow: 0 18px 25px rgba(37, 99, 235, 0.35);
+}
+
+.primary-button:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 22px 32px rgba(37, 99, 235, 0.4);
+}
+
+.primary-button:active {
+  transform: translateY(0);
+}
+
+.secondary-button {
+  color: #1d4ed8;
+  background: transparent;
+  border: 2px solid rgba(37, 99, 235, 0.65);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
+}
+
+.secondary-button:hover {
+  background: rgba(37, 99, 235, 0.1);
+}
+
+.secondary-button:active {
+  transform: translateY(1px);
+}
+
+.message {
+  margin: 0;
+  text-align: center;
+  font-size: clamp(0.95rem, 2.5vw, 1.05rem);
+  color: #334155;
+  max-width: 540px;
+}
+
+@media (max-width: 640px) {
+  .app {
+    padding: 2rem 1.25rem 2.5rem;
   }
-  to {
-    transform: rotate(360deg);
+
+  .status-panel {
+    gap: 1rem;
   }
-}
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
+  .controls {
+    width: 100%;
   }
-}
 
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
+  .primary-button,
+  .secondary-button {
+    flex: 1;
+    padding: 0.8rem 1.5rem;
+  }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,34 +1,208 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { useEffect, useState } from 'react'
 import './App.css'
 
+const HOLE_COUNT = 9
+const GAME_DURATION = 30
+const MOLE_SPEED = 800
+const BEST_SCORE_STORAGE_KEY = 'whack-a-mole-best-score'
+
+type GameStatus = 'idle' | 'playing' | 'finished'
+
+const holeIndices = Array.from({ length: HOLE_COUNT }, (_, index) => index)
+
+const clampPercentage = (value: number) => Math.max(0, Math.min(100, value))
+
 function App() {
-  const [count, setCount] = useState(0)
+  const [status, setStatus] = useState<GameStatus>('idle')
+  const [score, setScore] = useState(0)
+  const [timeLeft, setTimeLeft] = useState(GAME_DURATION)
+  const [moleIndex, setMoleIndex] = useState<number | null>(null)
+  const [bestScore, setBestScore] = useState<number | null>(null)
+  const [isNewRecord, setIsNewRecord] = useState(false)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    const storedBest = window.localStorage.getItem(BEST_SCORE_STORAGE_KEY)
+    if (storedBest) {
+      const parsedBest = Number.parseInt(storedBest, 10)
+      if (!Number.isNaN(parsedBest)) {
+        setBestScore(parsedBest)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (status !== 'playing') {
+      return
+    }
+
+    const timer = window.setInterval(() => {
+      setTimeLeft((current) => {
+        if (current <= 1) {
+          window.clearInterval(timer)
+          setStatus('finished')
+          return 0
+        }
+        return current - 1
+      })
+    }, 1000)
+
+    return () => window.clearInterval(timer)
+  }, [status])
+
+  useEffect(() => {
+    if (status !== 'playing') {
+      setMoleIndex(null)
+      return
+    }
+
+    const showNextMole = () => {
+      setMoleIndex((previous) => {
+        let next = Math.floor(Math.random() * HOLE_COUNT)
+        if (previous !== null && HOLE_COUNT > 1) {
+          while (next === previous) {
+            next = Math.floor(Math.random() * HOLE_COUNT)
+          }
+        }
+        return next
+      })
+    }
+
+    showNextMole()
+    const moleTimer = window.setInterval(showNextMole, MOLE_SPEED)
+
+    return () => window.clearInterval(moleTimer)
+  }, [status])
+
+  useEffect(() => {
+    if (status !== 'finished') {
+      setIsNewRecord(false)
+      return
+    }
+
+    setBestScore((previous) => {
+      const newBest = previous === null ? score : Math.max(previous, score)
+      const updated = previous === null || score > previous
+      setIsNewRecord(updated)
+
+      if (typeof window !== 'undefined' && (updated || previous === null)) {
+        window.localStorage.setItem(BEST_SCORE_STORAGE_KEY, String(newBest))
+      }
+
+      return newBest
+    })
+  }, [status, score])
+
+  const startGame = () => {
+    setScore(0)
+    setTimeLeft(GAME_DURATION)
+    setStatus('playing')
+  }
+
+  const stopGame = () => {
+    setStatus('finished')
+    setTimeLeft(0)
+  }
+
+  const handleHoleClick = (index: number) => {
+    if (status !== 'playing' || index !== moleIndex) {
+      return
+    }
+
+    setScore((current) => current + 1)
+    setMoleIndex(null)
+  }
+
+  const timeProgress =
+    status === 'playing'
+      ? clampPercentage((timeLeft / GAME_DURATION) * 100)
+      : status === 'idle'
+        ? 100
+        : 0
+
+  const message = (() => {
+    if (status === 'idle') {
+      return '「ゲームスタート」を押すとカウントダウンが始まります。光った穴を素早くクリックしてスコアを伸ばしましょう！'
+    }
+    if (status === 'playing') {
+      return '出てきたモグラをクリックしてハイスコアを狙え！同じ穴に連続で出現しないので目を素早く動かしてみてください。'
+    }
+    const base = `お疲れさま！今回のスコアは ${score} 点でした。`
+    if (isNewRecord && bestScore !== null) {
+      return `${base} ベストスコアを ${bestScore} 点に更新！`
+    }
+    if (bestScore !== null) {
+      return `${base} ベストスコアは ${bestScore} 点です。`
+    }
+    return base
+  })()
 
   return (
-    <>
-      <div>
-        <a href="https://vitejs.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
+    <div className="app">
+      <header className="header">
+        <h1>モグラたたきミニゲーム</h1>
+        <p className="lead">
+          制限時間 {GAME_DURATION} 秒の間に、穴から顔を出すモグラをできるだけ多くクリックしよう！
         </p>
+      </header>
+
+      <section className="status-panel" aria-label="ゲームの状況">
+        <div className="status-block" role="status">
+          <span className="status-label">スコア</span>
+          <span className="status-value">{score}</span>
+        </div>
+        <div className="status-block time" role="status">
+          <span className="status-label">タイム</span>
+          <span className="status-value">{timeLeft}</span>
+          <div className="time-track" aria-hidden="true">
+            <div className="time-progress" style={{ width: `${timeProgress}%` }} />
+          </div>
+        </div>
+        <div className="status-block" role="status">
+          <span className="status-label">ベスト</span>
+          <span className="status-value">{bestScore ?? '—'}</span>
+        </div>
+      </section>
+
+      <div className="board" role="grid" aria-label="モグラたたきのフィールド">
+        {holeIndices.map((index) => {
+          const hasMole = index === moleIndex
+          return (
+            <button
+              key={index}
+              type="button"
+              className={`hole${hasMole ? ' has-mole' : ''}`}
+              onClick={() => handleHoleClick(index)}
+              disabled={status !== 'playing'}
+              aria-label={hasMole ? 'モグラをたたく' : '空の穴'}
+              role="gridcell"
+            >
+              <span className="hole-inner">
+                <span className="hole-shadow" />
+                <span className="mole" />
+              </span>
+            </button>
+          )
+        })}
       </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+
+      <div className="controls">
+        {status !== 'playing' ? (
+          <button type="button" className="primary-button" onClick={startGame}>
+            {status === 'finished' ? 'もう一度プレイ' : 'ゲームスタート'}
+          </button>
+        ) : (
+          <button type="button" className="secondary-button" onClick={stopGame}>
+            あきらめる
+          </button>
+        )}
+      </div>
+
+      <p className="message">{message}</p>
+    </div>
   )
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,68 +1,37 @@
 :root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
+  font-family: 'Noto Sans JP', 'Hiragino Kaku Gothic ProN', 'Yu Gothic', system-ui, -apple-system,
+    BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.6;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
+  color: #0f172a;
+  background-color: #dbeafe;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  color-scheme: light;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
   min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.5rem, 5vw, 3rem) clamp(1rem, 4vw, 2.5rem);
+  background: radial-gradient(120% 120% at 50% 0%, #bfdbfe 0%, #93c5fd 40%, #60a5fa 72%, #2563eb 100%);
 }
 
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+a {
+  color: inherit;
 }


### PR DESCRIPTION
## Summary
- replace the default counter view with a whack-a-mole style mini game that tracks time, score, and personal bests via localStorage
- add rich styling for the game board, status cards, and controls to deliver a playful arcade atmosphere
- refresh global typography and layout rules to support the new presentation

## Testing
- npm run build *(fails: project scripts are configured for Next.js and abort because no `pages` or `app` directory exists in this Vite-based setup)*
- npm run lint *(fails: Next.js lint command expects a `pages` or `app` directory that is absent in this project)*

------
https://chatgpt.com/codex/tasks/task_b_68d3fb4216248328aab92505ecbf2658